### PR TITLE
Fix hostnames and aliases

### DIFF
--- a/lib/vagrant-hosts/provisioner/linux.rb
+++ b/lib/vagrant-hosts/provisioner/linux.rb
@@ -64,9 +64,9 @@ class VagrantHosts::Provisioner::Linux
       m_hostname = m.config.vm.hostname
 
       m_networks.each do |(net_type, opts)|
-        next unless net_types == :private_network
+        next unless net_type == :private_network
         addr = opts[:ip]
-        hosts << [addr, [m_hostname, @machine.name]]
+        hosts << [addr, [m.name, m_hostname]]
       end
     end
 


### PR DESCRIPTION
Before this commit host entries would be `<ip> <hostname> <my name>` for
all entries. If `config.vm.hostname` was nil (the default) then primary
name would be empty. Secondly, nodes adding their own hostname as an
alias to all host entries is just plain weird.

Now entries should be `<ip> <defined name> <hostname>`. And will not be
blank because nodes can have either a defined name, a hostname, or both.
