### PR TITLE
Assign hostname to 127.0.1.1 if available

### DIFF
--- a/lib/vagrant-hosts/provisioner/linux.rb
+++ b/lib/vagrant-hosts/provisioner/linux.rb
@@ -50,9 +50,12 @@ class VagrantHosts::Provisioner::Linux
   end
 
   def local_hosts
+    hostname = @machine.config.vm.hostname
+    hostname ||= @machine.name # Fall back if hostname is unset.
+
     [
       ['127.0.0.1', ['localhost']],
-      ['127.0.1.1', [@machine.name]],
+      ['127.0.1.1', [hostname]],
     ]
   end
 


### PR DESCRIPTION
This patch assigns `@machine.config.vm.hostname` to 127.0.1.1 and falls back to
`@machine.name` if the hostname was not set.

The hostname can be set to something resembling a fqdn, which allows `facter
fqdn` to return a value. This in turn prevents a bunch of problems that can
occur in the Puppet ecosystem if Facter cannot determine a fully qualified
domain name.
