### PR TITLE
Fix registration of hosts with config builder

### DIFF
--- a/lib/vagrant-hosts/config_builder.rb
+++ b/lib/vagrant-hosts/config_builder.rb
@@ -25,7 +25,7 @@ module VagrantHosts
         end
       end
 
-      ::ConfigBuilder::Model::Provisioner.register('shell', self)
+      ::ConfigBuilder::Model::Provisioner.register('hosts', self)
     end
   end
 end


### PR DESCRIPTION
The hosts provider should be registered as `hosts` and not `shell`.
