### PR TITLE
vagrant-hosts fails due to "uninitialized constant Tempfile (NameError)" in posix.rb

### DIFF
--- a/lib/vagrant-hosts/cap/sync_hosts/posix.rb
+++ b/lib/vagrant-hosts/cap/sync_hosts/posix.rb
@@ -1,4 +1,7 @@
 # Provide a base class for syncing hosts entries on POSIX systems.
+
+require 'tempfile'
+
 class VagrantHosts::Cap::SyncHosts::POSIX < VagrantHosts::Cap::SyncHosts::Base
 
   private


### PR DESCRIPTION
**Error description**

Using Ruby 2.x (2.0.0-p195) the provisioning phase for vagrant-hosts will fail with the following error:

```
$ vagrant provision server1
~/.vagrant.d/gems/gems/vagrant-hosts-2.0.0/lib/vagrant-hosts/cap/sync_hosts/posix.rb:7:in `upload_tmphosts': uninitialized constant VagrantHosts::Cap::SyncHosts::POSIX::Tempfile (NameError)
    from ~/.vagrant.d/gems/gems/vagrant-hosts-2.0.0/lib/vagrant-hosts/cap/sync_hosts/posix.rb:14:in `update_hosts'
    from ~/.vagrant.d/gems/gems/vagrant-hosts-2.0.0/lib/vagrant-hosts/cap/sync_hosts/base.rb:18:in `sync!'
    from ~/.vagrant.d/gems/gems/vagrant-hosts-2.0.0/lib/vagrant-hosts/cap/sync_hosts/base.rb:5:in `sync_hosts'
[...rest omitted...]
```

**How to reproduce (see Environment below)**

Add something similar to the following to `Vagrantfile`.  Basically, this follows the recommended syntax of vagrant-hosts to autodetect internal network addresses and autoconfigure hosts.

```
# In Vagrantfile
  c.vm.provider :virtualbox do |vb, override|
    override.vm.provision :hosts
```

**Environment**
- Vagrant 1.3.5 (x86_64), i.e. the latest release -- also triggered with 1.3.1 (x86_64)
- OS: RHEL/CentOS 6 64-bit
- Ruby: 2.0.0-p195
- vagrant-hosts: 2.0.0 (latest release)

**How to fix**

See pull the request.  Apparently one must explicitly require `tempfile` so that `Tempfile.new(...)` in `posix.rb` does not trigger the error above.
