### PR TITLE
Fix function interface bugs

### DIFF
--- a/lib/vagrant-hosts/addresses.rb
+++ b/lib/vagrant-hosts/addresses.rb
@@ -5,10 +5,10 @@ module VagrantHosts::Addresses
   def all_hosts(config)
 
     all_hosts = []
-    all_hosts += local_hosts
+    all_hosts += local_hosts(@machine)
 
     if config.autoconfigure
-      all_hosts += vagrant_hosts
+      all_hosts += vagrant_hosts(@env)
     end
     all_hosts += config.hosts
 


### PR DESCRIPTION
Changes to the local_hosts and vagrant_hosts functions in VagrantHosts::Addresses made passing a "machine" or "env" argument along mandatory, but a few invocations got missed and failed to pass along an argument. This commit fixes those omissions.
