### PR TITLE
Updated README. IP addresses in last example needs to be quoted.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -61,7 +61,7 @@ Use autodetection with manual entries
         node.vm.network :private_network, :ip => '10.20.1.2'
         node.vm.provision :hosts do |provisioner|
           provisioner.autoconfigure = true
-          provisioner.add_host 172.16.3.10, ['yum.mirror.local']
+          provisioner.add_host '172.16.3.10', ['yum.mirror.local']
         end
 
       end
@@ -71,7 +71,7 @@ Use autodetection with manual entries
         node.vm.network :private_network, :ip => '10.20.1.3'
         node.vm.provision :hosts do |provisioner|
           provisioner.autoconfigure = true
-          provisioner.add_host 172.16.3.11, ['apt.mirror.local']
+          provisioner.add_host '172.16.3.11', ['apt.mirror.local']
         end
       end
     end


### PR DESCRIPTION
Not quoting IPs like in that last example causes floating point errors:

/Users/richard.burroughs/vagrantfiles/precise64/Vagrantfile:59: no .<digit> floating literal anymore; put 0 before dot
    provisioner.add_host 172.16.3.11, ['apt.mirror.local']
                                ^
/Users/richard.burroughs/vagrantfiles/precise64/Vagrantfile:59: syntax error, unexpected tFLOAT, expecting '('
    provisioner.add_host 172.16.3.11, ['apt.mirror.local']
