### PR TITLE
The hostname should not be a localhost address.

### DIFF
--- a/lib/vagrant-hosts/addresses.rb
+++ b/lib/vagrant-hosts/addresses.rb
@@ -33,7 +33,6 @@ module VagrantHosts::Addresses
   def local_hosts(machine)
     [
       ['127.0.0.1', ['localhost']],
-      ['127.0.1.1', hostnames_for_machine(machine)],
     ]
   end
 


### PR DESCRIPTION
This causes problems for all manner of software. Its also not "faster."
Modern networking stacks detect when IP address are bound to a
local interface and "do the right thing."

Also this code causes duplicate entries in hosts which won't break things.
But isn't a best practice. Fixes #24.
