### PR TITLE
Add support for Vagrant 1.5.x

### DIFF
--- a/lib/vagrant-hosts/cap/sync_hosts/base.rb
+++ b/lib/vagrant-hosts/cap/sync_hosts/base.rb
@@ -28,7 +28,7 @@ class VagrantHosts::Cap::SyncHosts::Base
     case Vagrant::VERSION
     when /^1\.1/
       @machine.guest.change_host_name(name)
-    when /^1\.[234]/
+    when /^1\.[2-5]/
       @machine.guest.capability(:change_host_name, name)
     else
       raise VagrantHosts::Cap::SyncHosts::UnknownVersion, :vagrant_version => Vagrant::VERSION


### PR DESCRIPTION
The vagrant-hosts plugin is very opinionaed about what versions of Vagrant it will run under. This patch makes sure that it's opinion of Vagrant 1.5.x is a positive one.
