### PR TITLE
Update Version Check for Vagrant 1.6

### DIFF
--- a/lib/vagrant-hosts/cap/sync_hosts/base.rb
+++ b/lib/vagrant-hosts/cap/sync_hosts/base.rb
@@ -28,7 +28,7 @@ class VagrantHosts::Cap::SyncHosts::Base
     case Vagrant::VERSION
     when /^1\.1/
       @machine.guest.change_host_name(name)
-    when /^1\.[2-5]/
+    when /^1\.[2-6]/
       @machine.guest.capability(:change_host_name, name)
     else
       raise VagrantHosts::Cap::SyncHosts::UnknownVersion, :vagrant_version => Vagrant::VERSION


### PR DESCRIPTION
Vagrant 1.6.0 (and now 1.6.1) has been released change_host_name
API/calls remain unchanged/broken in my testing/knowledge. Made this
change and tested in my set ups, works fine. Should update to Vagrant
1.6.x support without an issue as far as I can tell/know/have tested.
