### PR TITLE
Ignore unconfigured machines from Vagrant env

### DIFF
--- a/lib/vagrant-hosts/addresses.rb
+++ b/lib/vagrant-hosts/addresses.rb
@@ -53,7 +53,13 @@ module VagrantHosts::Addresses
 
   # @return [Array<Vagrant::Machine>]
   def all_machines(env)
-    env.active_machines.map { |vm_id| env.machine(*vm_id) }
+    env.active_machines.map do |vm_id|
+      begin
+        env.machine(*vm_id)
+      rescue Vagrant::Errors::MachineNotFound
+        nil
+      end
+    end.compact
   end
 
 end


### PR DESCRIPTION
Because `env.active_machines` can return machines no longer present in the Vagrantfile ([doc](http://rubydoc.info/github/mitchellh/vagrant/master/Vagrant/Environment:active_machines)), an "orphan" machine will not be configured and `env.machine` will throw `Vagrant::Errors::MachineNotFound`. It then prints this error message: "The machine with the name '...' was not found configured for this Vagrant
environment".

It can happen when having a multi-nodes Vagrantfile and playing with adding and removing node definitions.
