### PR TITLE
Support fqdn-named Windows Vagrant machines

### DIFF
--- a/lib/vagrant-hosts/cap/sync_hosts/windows.rb
+++ b/lib/vagrant-hosts/cap/sync_hosts/windows.rb
@@ -74,7 +74,8 @@ function Set-PrimaryDnsSuffix {
   [ComputerSystem.Identification]::SetPrimaryDnsSuffix($Suffix)
 }
 
-Set-PrimaryDnsSuffix "#{domainname}"
+$success = Set-PrimaryDnsSuffix "#{domainname}"
+if ($success -eq $True) {exit 0} else {exit 1}
     END_OF_POWERSHELL
 
     @machine.communicate.sudo(powershell)

--- a/lib/vagrant-hosts/cap/sync_hosts/windows.rb
+++ b/lib/vagrant-hosts/cap/sync_hosts/windows.rb
@@ -19,4 +19,23 @@ class VagrantHosts::Cap::SyncHosts::Windows < VagrantHosts::Cap::SyncHosts::Base
     @machine.communicate.sudo(script.join("; "))
   end
 
+  # Windows needs a modification of the base method because Windows guest names
+  # cannot be fully-qualified domain names (they cannot contain the "."
+  # character). Therefore, modify the input name to convert illegal characters
+  # to legal replacements.
+  #
+  # @param name [String] The new hostname to apply on the guest
+  def change_host_name(name)
+    safechars = name.gsub(%r{[\\/.@*,"]}, '-')
+
+    safename = if (safechars.length > 15)
+                firstname = name.split(%r{[\\/.@*,"]}).first
+                firstname.length > 0 ? firstname : safechars.truncate(15)
+              else
+                safechars
+              end
+
+    super(safename)
+  end
+
 end

--- a/lib/vagrant-hosts/cap/sync_hosts/windows.rb
+++ b/lib/vagrant-hosts/cap/sync_hosts/windows.rb
@@ -26,16 +26,58 @@ class VagrantHosts::Cap::SyncHosts::Windows < VagrantHosts::Cap::SyncHosts::Base
   #
   # @param name [String] The new hostname to apply on the guest
   def change_host_name(name)
-    safechars = name.gsub(%r{[\\/.@*,"]}, '-')
 
-    safename = if (safechars.length > 15)
-                firstname = name.split(%r{[\\/.@*,"]}).first
-                firstname.length > 0 ? firstname : safechars.truncate(15)
-              else
-                safechars
-              end
+    # First set the machine name (hostname)
+    components = name.split('.')
+    hostname   = components.first
+    domainname = components.slice(1, components.size).join('.')
 
-    super(safename)
+    super(hostname)
+
+    # Next set the Primary DNS Suffix, if it makes sense (domainname)
+    unless domainname.empty?
+      change_domain_name(domainname)
+    end
+  end
+
+  def change_domain_name(domainname)
+    # Source: http://poshcode.org/2958
+    # Note that whitespace is important in this inline powershell script due
+    # to the use of a here-string.
+    powershell = <<-END_OF_POWERSHELL
+function Set-PrimaryDnsSuffix {
+  param ([string] $Suffix)
+
+  # http://msdn.microsoft.com/en-us/library/ms724224(v=vs.85).aspx
+  $ComputerNamePhysicalDnsDomain = 6
+
+  Add-Type -TypeDefinition @"
+  using System;
+  using System.Runtime.InteropServices;
+
+  namespace ComputerSystem {
+      public class Identification {
+          [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+          static extern bool SetComputerNameEx(int NameType, string lpBuffer);
+
+          public static bool SetPrimaryDnsSuffix(string suffix) {
+              try {
+                  return SetComputerNameEx($ComputerNamePhysicalDnsDomain, suffix);
+              }
+              catch (Exception) {
+                  return false;
+              }
+          }
+      }
+  }
+"@
+  [ComputerSystem.Identification]::SetPrimaryDnsSuffix($Suffix)
+}
+
+Set-PrimaryDnsSuffix "#{domainname}"
+    END_OF_POWERSHELL
+
+    @machine.communicate.sudo(powershell)
   end
 
 end


### PR DESCRIPTION
Windows machine names cannot contain special characters and cannot be longer than 15 characters in length. However, it's reasonable to define Vagrant machines named by FQDN rather than windows-compliant short name.

This commit modifies the Windows change_hostname method to sanitize the vagrant machine name before attempting to change the name in the guest OS. It does so by converting illegal characters to "-", and if the name is too long truncating at the first illegal character.

The effective result of this should be that if a vagrant Windows machine has a name such as `win1.longdomain.evenlonger.net`, the vagrant-hosts provisioner will assign the guest OS the machine name `win1`.