### PR TITLE
Add a config option to disable changing the hostname

### DIFF
--- a/lib/vagrant-hosts/cap/sync_hosts/base.rb
+++ b/lib/vagrant-hosts/cap/sync_hosts/base.rb
@@ -20,8 +20,10 @@ class VagrantHosts::Cap::SyncHosts::Base
     # FIXME: Write tests for this behavior.
     # TODO: Move this behavior into a config block on the hosts provisioner
     # so that this capability can remain focused on updating /etc/hosts.
-    hostname = @machine.config.vm.hostname || @machine.name.to_s
-    change_host_name(hostname)
+    if @config.change_hostname
+      hostname = @machine.config.vm.hostname || @machine.name.to_s
+      change_host_name(hostname)
+    end
 
     # call to method not implemented by abstract base class
     update_hosts

--- a/lib/vagrant-hosts/config.rb
+++ b/lib/vagrant-hosts/config.rb
@@ -41,6 +41,15 @@ module VagrantHosts
     #   @since 2.7.0
     attr_accessor :imports
 
+    # @!attribute [rw] change_hostname
+    #   @return [TrueClass, FalseClass] When set to true, running the hosts
+    #   provisioner on this VM will change the hostname of the machine to be
+    #   the hostname configured or the name of the machine.
+    #   Defaults to 'true'.
+    #
+    #   @since 2.8.4
+    attr_accessor :change_hostname
+
     def initialize
       @hosts = []
       @exports = {}
@@ -48,6 +57,7 @@ module VagrantHosts
       @autoconfigure = UNSET_VALUE
       @add_localhost_hostnames = UNSET_VALUE
       @sync_hosts = UNSET_VALUE
+      @change_hostname = UNSET_VALUE
     end
 
     # Register a host for entry
@@ -81,6 +91,7 @@ module VagrantHosts
       end
 
       @sync_hosts = false if @sync_hosts == UNSET_VALUE
+      @change_hostname = true if @change_hostname == UNSET_VALUE
     end
 
     # @param other [VagrantHosts::Config]

--- a/lib/vagrant-hosts/config_builder/1_x.rb
+++ b/lib/vagrant-hosts/config_builder/1_x.rb
@@ -19,6 +19,8 @@ module VagrantHosts
       def_model_attribute :exports
       # @!attribute [rw] exports
       def_model_attribute :imports
+      # @!attribute [rw] change_hostname
+      def_model_attribute :change_hostname
 
       # @private
       def configure_exports(config, val)

--- a/vagrant-hosts.gemspec
+++ b/vagrant-hosts.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.email    = ['adrien@somethingsinistral.net', 'source@sharpsteen.net']
   gem.homepage = 'https://github.com/oscar-stack/vagrant-hosts'
 
-  gem.has_rdoc = true
   gem.license  = 'Apache 2.0'
 
   gem.files        = %x{git ls-files -z}.split("\0")


### PR DESCRIPTION
Prior to this PR, when the provisioner was enabled on a machine, it
would always change the hostname of the machine. This PR adds a new
config option to disable this feature. 

This is required to use the hosts provider with the vmpooler provisioner where the hostname cannot be changed.